### PR TITLE
Add task category support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ connection logic are found in `db/`.
    ```
 5. Navigate to `http://localhost:8000/` to view the task list. The admin panel is
    available at `http://localhost:8000/admin.php`.
+6. The `tasks` table now includes a `category` column. If upgrading an existing
+   installation run:
+   ```sql
+   ALTER TABLE tasks ADD COLUMN category VARCHAR(255);
+   ```
 
 ## Expired Task Reset
 

--- a/api/tasks.php
+++ b/api/tasks.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/../db/db.php';
 header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    $stmt = $pdo->query("SELECT * FROM tasks ORDER BY date_posted DESC");
+    $stmt = $pdo->query("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks ORDER BY date_posted DESC");
     $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     foreach ($tasks as &$task) {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -12,6 +12,7 @@ CREATE TABLE tasks (
   title VARCHAR(255),
   description TEXT,
   links TEXT,
+  category VARCHAR(255),
   attachments TEXT,
   reward DECIMAL(10,2),
   estimated_minutes INT,


### PR DESCRIPTION
## Summary
- include `category` column in schema
- fetch `category` in the tasks API
- explain how to add the column when setting up

## Testing
- `php -l api/tasks.php`
- `php -l api/admin_tasks.php`

------
https://chatgpt.com/codex/tasks/task_e_68727a8e57ac83328a223df8688edde1