### PR TITLE
Add comment support for task submissions and quits

### DIFF
--- a/api/quit_task.php
+++ b/api/quit_task.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../db/db.php';
 $data = json_decode(file_get_contents("php://input"), true);
 $taskId = $data["task_id"] ?? null;
 $passcode = $data["passcode"] ?? "";
+$comment = trim($data["comment"] ?? "");
 
 if (!$taskId || !$passcode) {
   http_response_code(400);
@@ -15,7 +16,7 @@ if (!$taskId || !$passcode) {
   exit;
 }
 
-$stmt = $pdo->prepare("UPDATE tasks SET status = 'available', assigned_to = NULL, start_time = NULL WHERE id = ? AND assigned_to = ?");
-$success = $stmt->execute([$taskId, $passcode]);
+$stmt = $pdo->prepare("UPDATE tasks SET status = 'available', assigned_to = NULL, start_time = NULL, quit_comment = ? WHERE id = ? AND assigned_to = ?");
+$success = $stmt->execute([$comment, $taskId, $passcode]);
 
 echo json_encode(["success" => $success]);

--- a/api/submit.php
+++ b/api/submit.php
@@ -3,6 +3,7 @@ require_once __DIR__ . '/../db/db.php';
 
 $passcode = $_POST['passcode'] ?? '';
 $taskId = intval($_POST['task_id'] ?? 0);
+$comment = trim($_POST['comment'] ?? '');
 
 if (!$passcode || !$taskId || !isset($_FILES['attachment'])) {
   http_response_code(400);
@@ -39,8 +40,8 @@ $pdo->beginTransaction();
 $stmt = $pdo->prepare("UPDATE tasks SET status = 'pending_review', submission_time = NOW() WHERE id = ?");
 $stmt->execute([$taskId]);
 
-$stmt = $pdo->prepare("INSERT INTO submissions (task_id, user_passcode, file_path, submitted_at) VALUES (?, ?, ?, NOW())");
-$stmt->execute([$taskId, $passcode, $uniqueName]);
+$stmt = $pdo->prepare("INSERT INTO submissions (task_id, user_passcode, file_path, comment, submitted_at) VALUES (?, ?, ?, ?, NOW())");
+$stmt->execute([$taskId, $passcode, $uniqueName, $comment]);
 
 $pdo->commit();
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -20,7 +20,8 @@ CREATE TABLE tasks (
   status ENUM('available', 'in_progress', 'pending_review', 'completed') DEFAULT 'available',
   assigned_to VARCHAR(255),
   start_time DATETIME,
-  submission_time DATETIME
+  submission_time DATETIME,
+  quit_comment TEXT
 );
 
 CREATE TABLE submissions (
@@ -28,6 +29,7 @@ CREATE TABLE submissions (
   task_id INT,
   user_passcode VARCHAR(255),
   file_path TEXT,
+  comment TEXT,
   submitted_at DATETIME,
   FOREIGN KEY (task_id) REFERENCES tasks(id)
 );

--- a/public/admin.php
+++ b/public/admin.php
@@ -3,7 +3,7 @@ require_once __DIR__ . '/../db/db.php';
 
 // Get pending review tasks with submission info
 $stmt = $pdo->query("
-  SELECT t.*, s.file_path, s.submitted_at, u.note
+  SELECT t.*, s.file_path, s.submitted_at, s.comment, u.note
   FROM tasks t
   JOIN submissions s ON t.id = s.task_id
   LEFT JOIN users u ON s.user_passcode = u.passcode
@@ -34,6 +34,7 @@ $tasks = $stmt->fetchAll();
       <p><strong>User:</strong> <?= htmlspecialchars($task['assigned_to']) ?></p>
       <p><strong>Submitted:</strong> <?= $task['submitted_at'] ?></p>
       <p><strong>Note:</strong> <?= htmlspecialchars($task['note'] ?? '—') ?></p>
+      <p><strong>Comment:</strong> <?= htmlspecialchars($task['comment'] ?? '—') ?></p>
       <a href="/wbt/uploads/<?= htmlspecialchars($task['file_path']) ?>" target="_blank">Download submission</a>
 		<div>      
 		<form action="/wbt/api/approve.php" method="POST">
@@ -81,6 +82,9 @@ $tasks = $stmt->fetchAll();
 	
 	</div>
     <div><?= nl2br(htmlspecialchars($task['description'])) ?>
+      <?php if (!empty($task['quit_comment'])): ?>
+        <p><strong>Last Quit:</strong> <?= htmlspecialchars($task['quit_comment']) ?></p>
+      <?php endif; ?>
 	
 		<?php
 			$dir = __DIR__ . "/../uploads/{$task['id']}/in";

--- a/public/assets/script.js
+++ b/public/assets/script.js
@@ -238,10 +238,14 @@ document.addEventListener("DOMContentLoaded", () => {
                     }
                 } else if (isOwner) {
                     actionHTML = `<form class="uploadForm" data-id="${task.id}" enctype="multipart/form-data" style="display:inline;">
-	          <input type="file" name="attachment" required />
-	          <button type="submit">Submit</button>
+                  <input type="file" name="attachment" required />
+                  <input type="text" name="comment" placeholder="Note (optional)" class="noteField" />
+                  <button type="submit">Submit</button>
               </form>
-              <button class="quitBtn" data-id="${task.id}">Quit</button>
+              <form class="quitForm" data-id="${task.id}" style="display:inline;">
+                  <input type="text" name="comment" placeholder="Note (optional)" class="noteField" />
+                  <button type="submit" class="quitBtn">Quit</button>
+              </form>
               `;
                 }
 
@@ -348,10 +352,12 @@ document.addEventListener("DOMContentLoaded", () => {
                     form.addEventListener("submit", e => {
                         e.preventDefault();
                         const fileInput = form.querySelector("input[name=attachment]");
+                        const commentInput = form.querySelector("input[name=comment]");
                         const formData = new FormData();
                         formData.append("attachment", fileInput.files[0]);
                         formData.append("task_id", task.id);
                         formData.append("passcode", passcode);
+                        if (commentInput) formData.append("comment", commentInput.value);
 
                         fetch("/wbt/api/submit.php", {
                             method: "POST",
@@ -368,14 +374,16 @@ document.addEventListener("DOMContentLoaded", () => {
                             });
                     });
 
-                    const quitBtn = div.querySelector(".quitBtn");
-                    if (quitBtn) {
-                        quitBtn.addEventListener("click", () => {
+                    const quitForm = div.querySelector(".quitForm");
+                    if (quitForm) {
+                        quitForm.addEventListener("submit", e => {
+                            e.preventDefault();
                             if (!confirm("Are you sure you want to quit this task?")) return;
+                            const comment = quitForm.querySelector("input[name=comment]").value;
                             fetch("/wbt/api/quit_task.php", {
                                 method: "POST",
                                 headers: { "Content-Type": "application/json" },
-                                body: JSON.stringify({ task_id: task.id, passcode })
+                                body: JSON.stringify({ task_id: task.id, passcode, comment })
                             })
                                 .then(res => res.json())
                                 .then(result => {


### PR DESCRIPTION
## Summary
- allow users to provide a note when submitting or quitting a task
- store submission comments in the database
- store quit comments with tasks
- display comments in the admin panel

## Testing
- `php -l api/submit.php`
- `php -l api/quit_task.php`
- `php -l public/admin.php`
- `php -l api/admin_tasks.php`
- `php -l api/approve.php`

------
https://chatgpt.com/codex/tasks/task_e_6872c091541083328d553db78ba36917