### PR TITLE
Add user ranking display

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ connection logic are found in `db/`.
    ```sql
    ALTER TABLE tasks ADD COLUMN category VARCHAR(255);
    ```
+7. A `last_rejected` column tracks the user whose submission was rejected.
+   To upgrade an existing database run:
+   ```sql
+   ALTER TABLE tasks ADD COLUMN last_rejected VARCHAR(255);
+   ```
 
 ## Expired Task Reset
 

--- a/api/reject.php
+++ b/api/reject.php
@@ -9,15 +9,15 @@ if (!$taskId) {
 }
 
 // Reset task status
-$stmt = $pdo->prepare("
-  UPDATE tasks
-  SET status = 'available',
-      assigned_to = NULL,
-      start_time = NULL,
-      submission_time = NULL
-  WHERE id = ?
-");
+$stmt = $pdo->prepare("SELECT assigned_to FROM tasks WHERE id = ?");
 $stmt->execute([$taskId]);
+$rejectedUser = $stmt->fetchColumn();
+
+// Reset task status and remember who was rejected
+$stmt = $pdo->prepare(
+    "UPDATE tasks SET status = 'available', assigned_to = NULL, start_time = NULL, submission_time = NULL, last_rejected = ? WHERE id = ?"
+);
+$stmt->execute([$rejectedUser, $taskId]);
 
 // Optional: delete submission record
 $stmt = $pdo->prepare("DELETE FROM submissions WHERE task_id = ?");

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -21,7 +21,8 @@ CREATE TABLE tasks (
   assigned_to VARCHAR(255),
   start_time DATETIME,
   submission_time DATETIME,
-  quit_comment TEXT
+  quit_comment TEXT,
+  last_rejected VARCHAR(255)
 );
 
 CREATE TABLE submissions (

--- a/public/assets/script.js
+++ b/public/assets/script.js
@@ -109,7 +109,15 @@ document.addEventListener("DOMContentLoaded", () => {
                     if (stats.last_submission) parts.push(`[last: ${new Date(stats.last_submission).toLocaleString()}]`);
 
                     const userMeta = parts.length ? `<span class="user-meta"> ${parts.join('')} </span>` : '';
-                    authStatus.innerHTML = `Authorized as [<strong>${passcode}</strong>]${userMeta} <button id="deauthBtn">Exit</button>`;
+
+                    let rankSpan = '';
+                    if (stats.completed_jobs > 0 && stats.rank) {
+                        const top = (stats.top10 || []).map((u, i) => `${i + 1}. ${u.assigned_to} ($${u.total})`).join('\n');
+                        const coeffTitle = `${Math.round(stats.payout_coeff * 100)}% payout coefficient`;
+                        rankSpan = `<span class="user-rank-meta">[<span class="user-rank" title="${top}">${stats.rank}</span>★<span class="user-coeff" title="${coeffTitle}">${stats.payout_coeff.toFixed(2)}</span>]</span>`;
+                    }
+
+                    authStatus.innerHTML = `Authorized as [<strong>${passcode}</strong>]${rankSpan}${userMeta} <button id="deauthBtn">Exit</button>`;
 
                     document.querySelectorAll('.user-metric.clickable').forEach(el => {
                         el.addEventListener('click', () => {
@@ -154,7 +162,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
 
 
-    fetch("/wbt/api/tasks.php")
+    const tasksUrl = passcode ? `/wbt/api/tasks.php?passcode=${encodeURIComponent(passcode)}` : "/wbt/api/tasks.php";
+    fetch(tasksUrl)
         .then(res => res.json())
         .then(tasks => {
             taskList.innerHTML = "";

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -262,3 +262,17 @@ div#taskListCompleted::before {
 .progress-stripe div:first-child {
     margin-left: 1px;
 }
+
+/* ===== User Ranking ===== */
+.user-rank-meta {
+    margin-left: 8px;
+    font-size: 0.9em;
+    white-space: nowrap;
+}
+.user-rank-meta .user-rank,
+.user-rank-meta .user-coeff {
+    font-weight: bold;
+}
+.user-rank-meta .user-coeff {
+    margin-left: 2px;
+}


### PR DESCRIPTION
## Summary
- compute rank and payout coefficient in `user_stats.php`
- show rank and coefficient in header on login
- style new rank display
- prevent retaking rejected tasks

## Testing
- `php -l api/user_stats.php`
- `php -l api/tasks.php`
- `php -l api/reject.php`
- `node --check public/assets/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6873431b822883328600efa1728b6edc