### PR TITLE
Add payout tracking

### DIFF
--- a/api/approve.php
+++ b/api/approve.php
@@ -47,6 +47,10 @@ $stmt->execute([$passcode]);
 $stmt = $pdo->prepare("UPDATE fund_bank SET total_funds = total_funds - ?, last_updated = NOW() WHERE id = 1");
 $stmt->execute([$total]);
 
+// Record payout
+$stmt = $pdo->prepare("INSERT INTO payouts (passcode, amount, paid_at) VALUES (?, ?, NOW())");
+$stmt->execute([$passcode, $total]);
+
 $pdo->commit();
 
 header("Location: /wbt/public/admin.php");

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -47,3 +47,10 @@ CREATE TABLE fund_bank (
 );
 
 INSERT INTO fund_bank (id, total_funds, last_updated) VALUES (1, 0.00, NOW());
+
+CREATE TABLE payouts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  passcode VARCHAR(255) NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  paid_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- define a new `payouts` table in the schema
- record payouts whenever a task is approved

## Testing
- `php -l api/approve.php`
- `php -l api/user_stats.php`


------
https://chatgpt.com/codex/tasks/task_e_68734811adf083328b195326617e4f8c