### PR TITLE
Implement user history page

### DIFF
--- a/api/history.php
+++ b/api/history.php
@@ -1,2 +1,40 @@
 <?php
-// TODO: Return user task history
+require_once __DIR__ . '/../db/db.php';
+header('Content-Type: application/json');
+
+$passcode = trim($_GET['passcode'] ?? '');
+if (!$passcode) {
+    echo json_encode([]);
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, start_time, submission_time, category FROM tasks WHERE assigned_to = ? AND status IN ('in_progress','pending_review','completed') ORDER BY date_posted DESC");
+$stmt->execute([$passcode]);
+$tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+foreach ($tasks as &$task) {
+    $dir = __DIR__ . '/../uploads/' . $task['id'] . '/in';
+    $attachments = [];
+    if (is_dir($dir)) {
+        foreach (scandir($dir) as $file) {
+            if ($file !== '.' && $file !== '..') {
+                $attachments[] = "/wbt/uploads/{$task['id']}/in/{$file}";
+            }
+        }
+    }
+    $task['attachments'] = $attachments;
+
+    if (in_array($task['status'], ['pending_review','completed'])) {
+        $subStmt = $pdo->prepare("SELECT file_path, comment, submitted_at FROM submissions WHERE task_id = ? ORDER BY submitted_at DESC LIMIT 1");
+        $subStmt->execute([$task['id']]);
+        if ($sub = $subStmt->fetch(PDO::FETCH_ASSOC)) {
+            $task['submission'] = [
+                'file' => '/wbt/uploads/' . $sub['file_path'],
+                'comment' => $sub['comment'],
+                'submitted_at' => $sub['submitted_at']
+            ];
+        }
+    }
+}
+
+echo json_encode($tasks);

--- a/public/assets/script.js
+++ b/public/assets/script.js
@@ -117,7 +117,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         rankSpan = `<span class="user-rank-meta">[<span class="user-rank" title="${top}">${stats.rank}</span><span class="user-star">★</span><span class="user-coeff" title="${coeffTitle}">${stats.payout_coeff.toFixed(2)}</span>]</span>`;
                     }
 
-                    authStatus.innerHTML = `Authorized as [<strong>${passcode}</strong>]${rankSpan}${userMeta} <button id="deauthBtn">Exit</button>`;
+                    const histLink = `history.php?user=${encodeURIComponent(passcode)}`;
+                    authStatus.innerHTML = `Authorized as [<strong><a href="${histLink}">${passcode}</a></strong>]${rankSpan}${userMeta} <button id="deauthBtn">Exit</button>`;
 
                     document.querySelectorAll('.user-metric.clickable').forEach(el => {
                         el.addEventListener('click', () => {

--- a/public/history.php
+++ b/public/history.php
@@ -1,2 +1,90 @@
 <?php
-// TODO: Render user history
+require_once __DIR__ . '/../db/db.php';
+
+$passcode = trim($_GET['user'] ?? $_GET['passcode'] ?? '');
+if (!$passcode) {
+    echo "Missing user";
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, start_time, submission_time, category FROM tasks WHERE assigned_to = ? AND status IN ('in_progress','pending_review','completed') ORDER BY date_posted DESC");
+$stmt->execute([$passcode]);
+$tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$inProgress = 0;
+$pending = 0;
+$completed = 0;
+foreach ($tasks as $t) {
+    if ($t['status'] === 'in_progress') $inProgress++;
+    elseif ($t['status'] === 'pending_review') $pending++;
+    elseif ($t['status'] === 'completed') $completed++;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title><?= htmlspecialchars($passcode) ?> History</title>
+    <link rel="stylesheet" href="assets/style.css?v=<?= time() ?>">
+    <style>
+        #taskList::before { content: '<?= htmlspecialchars($passcode) ?> History:'; }
+    </style>
+</head>
+<body>
+<div id="top-bar">
+    <div class="top-bar-left">
+        <div class="top-bar-icon"><img src="assets/windows-95-loading.gif" alt=""></div>
+        <div>
+            <strong>WBT 1.0</strong>
+            <span class="top-bar-info">[<span style="color:blue;"><strong><?= $inProgress ?></strong></span> in progress | <?= $pending ?> submitted | <?= $completed ?> completed]</span>
+        </div>
+    </div>
+    <div class="top-bar-right">
+        <a href="index.php">Back</a>
+    </div>
+</div>
+<div id="taskList">
+  <div class="task header">
+    <div>Title</div>
+    <div>Description</div>
+    <div>Time</div>
+    <div>Reward</div>
+    <div>Status</div>
+    <div>—</div>
+  </div>
+<?php foreach ($tasks as $task): ?>
+  <?php if ($task['status'] !== 'completed'): ?>
+    <div class="task <?= htmlspecialchars($task['status']) ?>">
+      <div>
+        <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+        <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
+        <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
+      </div>
+      <div><?= nl2br(htmlspecialchars($task['description'])) ?></div>
+      <div><?= $task['estimated_minutes'] ?> min</div>
+      <div>$<?= $task['reward'] ?></div>
+      <div><?= str_replace('_', ' ', $task['status']) ?></div>
+      <div></div>
+    </div>
+  <?php endif; ?>
+<?php endforeach; ?>
+</div>
+<div id="taskListCompleted">
+<?php foreach ($tasks as $task): ?>
+  <?php if ($task['status'] === 'completed'): ?>
+    <div class="task completed">
+      <div>
+        <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+        <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
+        <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
+      </div>
+      <div><?= nl2br(htmlspecialchars($task['description'])) ?></div>
+      <div><?= $task['estimated_minutes'] ?> min</div>
+      <div>$<?= $task['reward'] ?></div>
+      <div>completed</div>
+      <div></div>
+    </div>
+  <?php endif; ?>
+<?php endforeach; ?>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add server-side page to view a user's task history
- expose new API endpoint to query a user's history
- link history page from the authorization status UI

## Testing
- `php -l api/history.php`
- `php -l public/history.php`

------
https://chatgpt.com/codex/tasks/task_e_687393a993048332baac7b9de72ebd58