### PR TITLE
Improve user history display

### DIFF
--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -54,6 +54,9 @@ button {
     align-items: center;
     gap: 10px;
 }
+.top-bar-user {
+    white-space: nowrap;
+}
 .top-bar-right {
     margin-left: auto;
     display: flex;

--- a/public/history.php
+++ b/public/history.php
@@ -37,6 +37,7 @@ foreach ($tasks as $t) {
             <strong>WBT 1.0</strong>
             <span class="top-bar-info">[<span style="color:blue;"><strong><?= $inProgress ?></strong></span> in progress | <?= $pending ?> submitted | <?= $completed ?> completed]</span>
         </div>
+        <div class="top-bar-user">User: <strong><?= htmlspecialchars($passcode) ?></strong></div>
     </div>
     <div class="top-bar-right">
         <a href="index.php">Back</a>
@@ -68,7 +69,7 @@ foreach ($tasks as $t) {
   <?php endif; ?>
 <?php endforeach; ?>
 </div>
-<div id="taskListCompleted">
+<div id="taskListCompleted"<?= $completed > 0 ? '' : ' style="display:none;"' ?> >
 <?php foreach ($tasks as $task): ?>
   <?php if ($task['status'] === 'completed'): ?>
     <div class="task completed">


### PR DESCRIPTION
## Summary
- show the logged in user on the history page top bar
- reveal completed jobs when they exist

## Testing
- `php -l public/history.php`
- `php -l public/assets/style.css`


------
https://chatgpt.com/codex/tasks/task_e_68739b28baec8332b83d8679a3f2e82c