### PR TITLE
Fix back link on fund history page

### DIFF
--- a/public/fund_history.php
+++ b/public/fund_history.php
@@ -23,6 +23,22 @@ $transactions = $stmt->fetchAll();
 </tr>
 <?php endforeach; ?>
 </table>
-<p><a href="admin.php">Back to Admin</a></p>
+<?php
+$ref = $_SERVER['HTTP_REFERER'] ?? '';
+$back = 'index.php';
+if ($ref) {
+    $parts = parse_url($ref);
+    if ((!isset($parts['host']) || $parts['host'] === $_SERVER['HTTP_HOST']) && isset($parts['path'])) {
+        $path = basename($parts['path']);
+        if ($path && $path !== basename($_SERVER['SCRIPT_NAME'])) {
+            $back = ltrim($parts['path'], '/');
+            if (isset($parts['query'])) {
+                $back .= '?' . $parts['query'];
+            }
+        }
+    }
+}
+?>
+<p><a href="<?= htmlspecialchars($back) ?>">Back</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure fund history back link returns user to the referring page

## Testing
- `php -l public/history.php`
- `find public -name '*.php' -maxdepth 1 -print0 | xargs -0 -n1 php -l`
- `find api -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6873e90522348332be54f43b0310bb5c