### PR TITLE
Add simple admin password setup

### DIFF
--- a/api/admin_tasks.php
+++ b/api/admin_tasks.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!($_SESSION['admin_logged_in'] ?? false)) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
 require_once __DIR__ . '/../db/db.php';
 
 $action = $_POST['action'] ?? '';

--- a/api/approve.php
+++ b/api/approve.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!($_SESSION['admin_logged_in'] ?? false)) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
 require_once __DIR__ . '/../db/db.php';
 
 $taskId = intval($_POST['task_id'] ?? 0);

--- a/api/delete_attachment.php
+++ b/api/delete_attachment.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!($_SESSION['admin_logged_in'] ?? false)) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
 require_once __DIR__ . '/../db/db.php';
 
 $taskId = intval($_POST['task_id'] ?? 0);

--- a/api/deposit.php
+++ b/api/deposit.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!($_SESSION['admin_logged_in'] ?? false)) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
 require_once __DIR__ . '/../db/db.php';
 
 

--- a/api/reject.php
+++ b/api/reject.php
@@ -1,4 +1,10 @@
 <?php
+session_start();
+if (!($_SESSION['admin_logged_in'] ?? false)) {
+    http_response_code(403);
+    echo 'Unauthorized';
+    exit;
+}
 require_once __DIR__ . '/../db/db.php';
 
 $taskId = intval($_POST['task_id'] ?? 0);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -70,3 +70,10 @@ CREATE TABLE fund_transactions (
   description VARCHAR(255),
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE admin_user (
+  id INT PRIMARY KEY,
+  password_hash VARCHAR(255) NOT NULL
+);
+
+INSERT INTO admin_user (id, password_hash) VALUES (1, '');

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -301,3 +301,18 @@ div#taskListCompleted::before {
 .user-rank-meta .user-coeff:hover {
     text-decoration: underline;
 }
+
+/* ===== Admin Login ===== */
+.login-container {
+    margin: 120px auto;
+    max-width: 300px;
+    padding: 20px;
+    background: #fff;
+    border: 1px solid #999;
+    text-align: center;
+}
+
+.login-container input {
+    width: 100%;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- secure admin endpoints with a session-based login
- show a first-time password setup screen when no admin password exists
- add login/logout flow and CSS styles
- store admin password hash in new `admin_user` table

## Testing
- `php -l public/admin.php`
- `php -l api/deposit.php`
- `php -l api/admin_tasks.php`
- `php -l api/approve.php`
- `php -l api/reject.php`
- `php -l api/delete_attachment.php`

------
https://chatgpt.com/codex/tasks/task_e_687d2bf075048332b77016fa61ff9792