### PR TITLE
Improve admin task color coding

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -151,7 +151,7 @@ $bankFunds = $pdo->query("SELECT total_funds FROM fund_bank WHERE id = 1")->fetc
   <p>No tasks awaiting review.</p>
 <?php else: ?>
   <?php foreach ($pending as $task): ?>
-    <div class="task review-task">
+    <div class="task review-task pending_review">
       <div><strong><?= htmlspecialchars($task['title']) ?></strong></div>
       <div>
         <?= htmlspecialchars($task['assigned_to']) ?><br>
@@ -196,7 +196,7 @@ $bankFunds = $pdo->query("SELECT total_funds FROM fund_bank WHERE id = 1")->fetc
   <div><button type="submit">Add Task</button></div>
 </form>
 <?php foreach ($tasks as $task): ?>
-  <div class="task">
+  <div class="task <?= $task['status'] ?>">
     <div><strong><?= htmlspecialchars($task['title']) ?></strong>
 	      <form action="/wbt/api/admin_tasks.php" method="POST" style="display:inline;">
         <input type="hidden" name="action" value="delete">

--- a/public/assets/style.css
+++ b/public/assets/style.css
@@ -89,7 +89,9 @@ span > strong:hover {
 }
 .admin > .review-task {
     grid-template-columns: .5fr 1fr 3fr .5fr;
-    margin-bottom: 16px;
+    margin-bottom: 0;
+    row-gap: 0;
+    border: 2px solid orange;
 }
 .task:nth-child(odd) {
     background-color: #dfdfdf;


### PR DESCRIPTION
## Summary
- style pending review tasks with an orange border and remove extra spacing
- color-code admin task list items by status

## Testing
- `php -l public/admin.php`

------
https://chatgpt.com/codex/tasks/task_e_6883e412a97c83328b1bd98504a845dd