### PR TITLE
Fix admin all tasks

### DIFF
--- a/public/admin.php
+++ b/public/admin.php
@@ -108,8 +108,8 @@ foreach ($pending as &$p) {
 }
 unset($p);
 
-// Get all tasks (for listing + edit/delete)
-$stmt = $pdo->query("SELECT * FROM tasks ORDER BY date_posted DESC");
+// Get all tasks except those pending review (for listing + edit/delete)
+$stmt = $pdo->query("SELECT * FROM tasks WHERE status != 'pending_review' ORDER BY date_posted DESC");
 $tasks = $stmt->fetchAll();
 
 // Stats for top bar


### PR DESCRIPTION
## Summary
- hide tasks in the pending review state from admin `All Tasks` list

## Testing
- `find public -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6883e6c1b91c833286ae72045534b322