### PR TITLE
Fix countdown timer timezone

### DIFF
--- a/api/admin_tasks.php
+++ b/api/admin_tasks.php
@@ -6,6 +6,7 @@ if (!($_SESSION['admin_logged_in'] ?? false)) {
     exit;
 }
 require_once __DIR__ . '/../db/db.php';
+date_default_timezone_set('UTC');
 
 $action = $_POST['action'] ?? '';
 $title = trim($_POST['title'] ?? '');
@@ -42,7 +43,7 @@ function handleUploads($taskId): array {
 
 switch ($action) {
   case 'create':
-    $stmt = $pdo->prepare("INSERT INTO tasks (title, description, reward, estimated_minutes, date_posted, category) VALUES (?, ?, ?, ?, NOW(), ?)");
+    $stmt = $pdo->prepare("INSERT INTO tasks (title, description, reward, estimated_minutes, date_posted, category) VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), ?)");
     $stmt->execute([$title, $description, $reward, $minutes, $category]);
     $taskId = $pdo->lastInsertId(); // get inserted task id
     $attachments = handleUploads($taskId);

--- a/api/approve.php
+++ b/api/approve.php
@@ -6,6 +6,7 @@ if (!($_SESSION['admin_logged_in'] ?? false)) {
     exit;
 }
 require_once __DIR__ . '/../db/db.php';
+date_default_timezone_set('UTC');
 
 $taskId = intval($_POST['task_id'] ?? 0);
 $passcode = trim($_POST['passcode'] ?? '');
@@ -54,7 +55,7 @@ $stmt = $pdo->prepare("INSERT IGNORE INTO users (passcode) VALUES (?)");
 $stmt->execute([$passcode]);
 
 // Deduct from fund
-$stmt = $pdo->prepare("UPDATE fund_bank SET total_funds = total_funds - ?, last_updated = NOW() WHERE id = 1");
+$stmt = $pdo->prepare("UPDATE fund_bank SET total_funds = total_funds - ?, last_updated = UTC_TIMESTAMP() WHERE id = 1");
 $stmt->execute([$total]);
 
 // Record fund transaction
@@ -62,7 +63,7 @@ $stmt = $pdo->prepare("INSERT INTO fund_transactions (txn_type, amount, descript
 $stmt->execute([$total, 'Task ' . $taskId]);
 
 // Record payout
-$stmt = $pdo->prepare("INSERT INTO payouts (passcode, amount, paid_at) VALUES (?, ?, NOW())");
+$stmt = $pdo->prepare("INSERT INTO payouts (passcode, amount, paid_at) VALUES (?, ?, UTC_TIMESTAMP())");
 $stmt->execute([$passcode, $total]);
 
 $pdo->commit();

--- a/api/cron_check_expired.php
+++ b/api/cron_check_expired.php
@@ -1,7 +1,9 @@
 <?php
 require_once __DIR__ . '/../db/db.php';
+// ensure the script runs in UTC
+date_default_timezone_set('UTC');
 
 $stmt = $pdo->prepare("UPDATE tasks SET status = 'available', assigned_to = NULL, start_time = NULL
-  WHERE status = 'in_progress' AND TIMESTAMPDIFF(MINUTE, start_time, NOW()) > estimated_minutes");
+  WHERE status = 'in_progress' AND TIMESTAMPDIFF(MINUTE, start_time, UTC_TIMESTAMP()) > estimated_minutes");
 $stmt->execute();
 echo "Expired tasks reset: " . $stmt->rowCount();

--- a/api/deposit.php
+++ b/api/deposit.php
@@ -6,6 +6,7 @@ if (!($_SESSION['admin_logged_in'] ?? false)) {
     exit;
 }
 require_once __DIR__ . '/../db/db.php';
+date_default_timezone_set('UTC');
 
 
 $amount = isset($_POST['funds']) ? floatval($_POST['funds']) : 0;
@@ -16,7 +17,7 @@ if ($amount <= 0) {
 }
 
 $pdo->beginTransaction();
-$stmt = $pdo->prepare("UPDATE fund_bank SET total_funds = total_funds + ?, last_updated = NOW() WHERE id = 1");
+$stmt = $pdo->prepare("UPDATE fund_bank SET total_funds = total_funds + ?, last_updated = UTC_TIMESTAMP() WHERE id = 1");
 $stmt->execute([$amount]);
 
 $stmt = $pdo->prepare("INSERT INTO fund_transactions (txn_type, amount, description) VALUES ('deposit', ?, 'Manual deposit')");

--- a/api/reset_expired.php
+++ b/api/reset_expired.php
@@ -13,10 +13,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // GLOBAL reset (from any user opening the page)
     if (isset($_POST['global_reset'])) {
         $stmt = $pdo->prepare("
-            UPDATE tasks 
-            SET status = 'available', assigned_to = NULL, start_time = NULL 
-            WHERE status = 'in_progress' 
-            AND TIMESTAMPDIFF(MINUTE, start_time, NOW()) > estimated_minutes
+            UPDATE tasks
+            SET status = 'available', assigned_to = NULL, start_time = NULL
+            WHERE status = 'in_progress'
+            AND TIMESTAMPDIFF(MINUTE, start_time, UTC_TIMESTAMP()) > estimated_minutes
         ");
         $stmt->execute();
 

--- a/api/submit.php
+++ b/api/submit.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../db/db.php';
+date_default_timezone_set('UTC');
 
 $passcode = $_POST['passcode'] ?? '';
 $taskId = intval($_POST['task_id'] ?? 0);
@@ -37,10 +38,10 @@ if (!move_uploaded_file($_FILES['attachment']['tmp_name'], $targetPath)) {
 // Mark task pending and create submission
 $pdo->beginTransaction();
 
-$stmt = $pdo->prepare("UPDATE tasks SET status = 'pending_review', submission_time = NOW() WHERE id = ?");
+$stmt = $pdo->prepare("UPDATE tasks SET status = 'pending_review', submission_time = UTC_TIMESTAMP() WHERE id = ?");
 $stmt->execute([$taskId]);
 
-$stmt = $pdo->prepare("INSERT INTO submissions (task_id, user_passcode, file_path, comment, submitted_at) VALUES (?, ?, ?, ?, NOW())");
+$stmt = $pdo->prepare("INSERT INTO submissions (task_id, user_passcode, file_path, comment, submitted_at) VALUES (?, ?, ?, ?, UTC_TIMESTAMP())");
 $stmt->execute([$taskId, $passcode, $uniqueName, $comment]);
 
 $pdo->commit();


### PR DESCRIPTION
## Summary
- handle all API timestamps in UTC
- send `start_time` as ISO-8601 to the client
- update cron and reset scripts to use UTC timestamps

## Testing
- `php -l api/tasks.php`
- `php -l api/submit.php`


------
https://chatgpt.com/codex/tasks/task_e_68849ff4f8548332b90ce153a1937caa