### PR TITLE
Add shareable task page and task ID filtering

### DIFF
--- a/api/tasks.php
+++ b/api/tasks.php
@@ -12,8 +12,12 @@ date_default_timezone_set('UTC');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $passcode = trim($_GET['passcode'] ?? '');
+    $taskId   = intval($_GET['id'] ?? 0);
 
-    if ($passcode) {
+    if ($taskId) {
+        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks WHERE id = ?");
+        $stmt->execute([$taskId]);
+    } elseif ($passcode) {
         $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks WHERE last_rejected IS NULL OR last_rejected != ? ORDER BY date_posted DESC");
         $stmt->execute([$passcode]);
     } else {

--- a/assets/script.js
+++ b/assets/script.js
@@ -259,7 +259,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     div.innerHTML = `
 
           <div>
-            <div><strong>[${task.id}] ${task.title}</strong></div>
+            <div><strong><a href="task.php?id=${task.id}">[${task.id}] ${task.title}</a></strong></div>
             <div class="task-meta">Posted on ${new Date(task.date_posted).toLocaleString()}</div>
             ${catSpans}
           </div>

--- a/history.php
+++ b/history.php
@@ -56,7 +56,7 @@ foreach ($tasks as $t) {
   <?php if ($task['status'] !== 'completed'): ?>
     <div class="task <?= htmlspecialchars($task['status']) ?>">
       <div>
-        <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+        <div><strong><a href="task.php?id=<?= $task['id'] ?>">[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></a></strong></div>
         <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
         <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
       </div>
@@ -74,7 +74,7 @@ foreach ($tasks as $t) {
   <?php if ($task['status'] === 'completed'): ?>
     <div class="task completed">
       <div>
-        <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+        <div><strong><a href="task.php?id=<?= $task['id'] ?>">[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></a></strong></div>
         <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
         <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
       </div>

--- a/task.php
+++ b/task.php
@@ -1,0 +1,84 @@
+<?php
+require_once __DIR__ . '/db/db.php';
+
+$id = intval($_GET['id'] ?? 0);
+if (!$id) {
+    echo "Missing task ID";
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, assigned_to, category FROM tasks WHERE id = ?");
+$stmt->execute([$id]);
+$task = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$task) {
+    echo "Task not found";
+    exit;
+}
+
+$attachments = [];
+$dir = __DIR__ . '/uploads/' . $task['id'] . '/in';
+if (is_dir($dir)) {
+    foreach (scandir($dir) as $file) {
+        if ($file !== '.' && $file !== '..') {
+            $attachments[] = "/uploads/{$task['id']}/in/{$file}";
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Task <?= htmlspecialchars($task['id']) ?></title>
+    <link rel="stylesheet" href="assets/style.css?v=<?= time() ?>">
+</head>
+<body>
+<div id="top-bar">
+    <div class="top-bar-left">
+        <div class="top-bar-icon"><img src="assets/windows-95-loading.gif" alt=""></div>
+        <div><strong>WBT 1.0</strong></div>
+    </div>
+    <div class="top-bar-right">
+        <a href="index.php">Back</a>
+    </div>
+</div>
+<div id="taskList">
+    <div class="task header">
+        <div>Title</div>
+        <div>Description</div>
+        <div>Time</div>
+        <div>Reward</div>
+        <div>Status</div>
+        <div>—</div>
+    </div>
+    <div class="task <?= htmlspecialchars($task['status']) ?>">
+        <div>
+            <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+            <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
+            <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
+        </div>
+        <div>
+            <?= nl2br(htmlspecialchars($task['description'])) ?>
+            <?php if (!empty($attachments)): ?>
+                <div class="attachments"><strong>Attachments:</strong>
+                    <ul>
+                        <?php foreach ($attachments as $file): ?>
+                            <li><a href="<?= htmlspecialchars($file) ?>" target="_blank"><?= htmlspecialchars(basename($file)) ?></a></li>
+                        <?php endforeach; ?>
+                    </ul>
+                </div>
+            <?php endif; ?>
+        </div>
+        <div><?= $task['estimated_minutes'] ?> min</div>
+        <div>$<?= $task['reward'] ?></div>
+        <div><?= str_replace('_', ' ', $task['status']) ?></div>
+        <div></div>
+    </div>
+</div>
+<footer>
+    &copy; 2025 <a href="http://docs.artsystema.com/" target="_blank">[j3 docs]</a>
+    <a href="https://github.com/artsystema/wbt" target="_blank">
+        <img src="assets/icons/github.svg" alt="GitHub">
+    </a>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow `api/tasks.php` to fetch a task by `id` parameter
- create `task.php` for sharing standalone task views
- link task titles to new shareable page in listings

## Testing
- `php -l api/tasks.php`
- `php -l task.php`
- `php -l history.php`
- `node --check assets/script.js`


------
https://chatgpt.com/codex/tasks/task_e_688fe0318fec8332a72d036b2c3dcb01