### PR TITLE
Enable taking tasks from task page

### DIFF
--- a/assets/task.js
+++ b/assets/task.js
@@ -1,0 +1,136 @@
+// JS for single task page
+document.addEventListener("DOMContentLoaded", () => {
+    let passcode = localStorage.getItem("passcode") || "";
+    const authField = document.getElementById("authField");
+    const authBtn = document.getElementById("authBtn");
+    const authStatus = document.getElementById("authStatus");
+    const bankDisplay = document.getElementById("bankDisplay");
+    const takeBtn = document.getElementById("takeBtn");
+    const taskRow = document.getElementById("taskRow");
+    const statusCell = document.getElementById("statusCell");
+
+    function updateAuthDisplay() {
+        if (passcode) {
+            authField.style.display = "none";
+            authBtn.style.display = "none";
+            authStatus.innerHTML = `Authorized as [<strong>${passcode}</strong>] <button id="deauthBtn">Exit</button>`;
+            document.getElementById("deauthBtn").addEventListener("click", () => {
+                localStorage.removeItem("passcode");
+                passcode = "";
+                authField.value = "";
+                updateAuthDisplay();
+                refreshStatus();
+            });
+        } else {
+            authField.style.display = "";
+            authBtn.style.display = "";
+            authStatus.textContent = "";
+        }
+    }
+
+    function refreshStatus() {
+        if (!taskRow || !statusCell) return;
+        const status = taskRow.dataset.status;
+        const owner = taskRow.dataset.owner;
+        const start = taskRow.dataset.start;
+        const estimatedMs = parseInt(taskRow.dataset.estimatedMs || "0");
+        statusCell.innerHTML = "";
+        if (status === "in_progress") {
+            if (passcode && passcode === owner && start) {
+                const endTime = new Date(start).getTime() + estimatedMs;
+                const countdown = document.createElement("span");
+                countdown.className = "countdown";
+                countdown.dataset.end = new Date(endTime).toISOString();
+                countdown.dataset.estimatedMs = estimatedMs;
+                statusCell.appendChild(countdown);
+                updateCountdowns();
+            } else {
+                statusCell.textContent = "in progress";
+            }
+        } else {
+            statusCell.textContent = status.replace(/_/g, " ");
+        }
+    }
+
+    authBtn.addEventListener("click", () => {
+        const val = authField.value.trim();
+        if (!val) return alert("Enter a passcode first.");
+        passcode = val;
+        localStorage.setItem("passcode", passcode);
+        updateAuthDisplay();
+        refreshStatus();
+    });
+
+    updateAuthDisplay();
+    refreshStatus();
+
+    if (takeBtn) {
+        takeBtn.addEventListener("click", () => {
+            if (!passcode) return alert("Enter passcode first.");
+            fetch("/api/tasks.php", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ task_id: takeBtn.dataset.id, passcode })
+            })
+                .then(res => res.json())
+                .then(result => {
+                    if (result.success) location.reload();
+                    else alert("Error: " + (result.error || "Unknown"));
+                });
+        });
+    }
+
+    function updateCountdowns() {
+        document.querySelectorAll(".countdown").forEach(el => {
+            const end = new Date(el.dataset.end);
+            const now = new Date();
+            const diff = end - now;
+            const estimatedMs = parseFloat(el.dataset.estimatedMs || "0");
+            if (isNaN(diff) || diff <= 0) {
+                el.textContent = "Expired";
+            } else {
+                const mins = diff / 60000;
+                const total = estimatedMs / 1000;
+                const elapsed = total - diff / 1000;
+                const progressRatio = Math.max(0, Math.min(1, elapsed / total));
+                const barSegments = 20;
+                const filledSegments = Math.round(barSegments * progressRatio);
+                const stripes = Array.from({ length: filledSegments }, () => '<div></div>').join("");
+                el.innerHTML = `
+                    <div class="progress-bar">
+                        <div class="progress-stripe">${stripes}</div>
+                    </div>in progress <br> [${formatTime(mins, true)}]
+                `;
+            }
+        });
+    }
+
+    function formatTime(minutes, includeSeconds = false) {
+        const totalMs = minutes * 60 * 1000;
+        const mins = Math.floor(totalMs / 60000);
+        const secs = Math.floor((totalMs % 60000) / 1000);
+        const hrs = Math.floor(mins / 60);
+        const remMins = mins % 60;
+
+        if (includeSeconds) {
+            if (hrs > 0) return `${hrs}h ${remMins}m ${secs}s`;
+            if (remMins > 0) return `${remMins}m ${secs}s`;
+            return `${secs}s`;
+        } else {
+            if (hrs > 0 && remMins > 0) return `${hrs}h ${remMins}m`;
+            if (hrs > 0) return `${hrs}h`;
+            return `${remMins}m`;
+        }
+    }
+
+    setInterval(updateCountdowns, 1000);
+    updateCountdowns();
+
+    fetch("/api/fund.php")
+        .then(res => res.json())
+        .then(bank => {
+            const text = `$${bank.available} available`;
+            const reserved = bank.reserved > 0 ? ` ($${bank.reserved} reserved)` : '';
+            bankDisplay.textContent = text + reserved;
+        });
+});

--- a/task.php
+++ b/task.php
@@ -7,7 +7,7 @@ if (!$id) {
     exit;
 }
 
-$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, assigned_to, category FROM tasks WHERE id = ?");
+$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, assigned_to, category, start_time FROM tasks WHERE id = ?");
 $stmt->execute([$id]);
 $task = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$task) {
@@ -29,16 +29,26 @@ if (is_dir($dir)) {
 <html>
 <head>
     <title>[<?= htmlspecialchars($task['id']) ?>] <?= htmlspecialchars($task['title']) ?></title>
+    <script src="assets/task.js?v=<?= time() ?>" defer></script>
     <link rel="stylesheet" href="assets/style.css?v=<?= time() ?>">
 </head>
 <body>
 <div id="top-bar">
     <div class="top-bar-left">
-        <a class="top-bar-icon" href="index.php"><img src="assets/windows-95-loading.gif" alt=""></a>
-        <div><strong>WBT 1.0</strong></div>
+        <a class="top-bar-icon" href="admin.php"><img src="assets/windows-95-loading.gif"></a>
+        <div title="Web-based Task Tracker 1.0">
+            <strong>WBT 1.0</strong>
+            <span id="taskStats" style="font-weight: normal; font-size: 0.9em;"></span>
+        </div>
+        <span class="top-bar-info">Balance: [<a href="fund_history.php"><span id="bankDisplay">Loading funds...</span></a>]</span>
     </div>
     <div class="top-bar-right">
-        <a href="index.php">Back</a>
+        <div id="authControls">
+            <input type="text" id="authField" placeholder="Enter passcode..." />
+            <button id="authBtn">Authorize</button>
+            <span id="authStatus"></span>
+        </div>
+        <a href="index.php" id="backBtn">Back</a>
     </div>
 </div>
 <div id="taskList">
@@ -48,9 +58,9 @@ if (is_dir($dir)) {
         <div>Time</div>
         <div>Reward</div>
         <div>Status</div>
-        <div>—</div>
+        <div>Action</div>
     </div>
-    <div class="task <?= htmlspecialchars($task['status']) ?>">
+    <div id="taskRow" class="task <?= htmlspecialchars($task['status']) ?>" data-id="<?= $task['id'] ?>" data-owner="<?= htmlspecialchars($task['assigned_to'] ?? '') ?>" data-status="<?= htmlspecialchars($task['status']) ?>" data-start="<?= htmlspecialchars($task['start_time'] ? gmdate('c', strtotime($task['start_time'])) : '') ?>" data-estimated-ms="<?= $task['estimated_minutes'] * 60000 ?>">
         <div>
             <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
             <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
@@ -70,8 +80,12 @@ if (is_dir($dir)) {
         </div>
         <div><?= $task['estimated_minutes'] ?> min</div>
         <div>$<?= $task['reward'] ?></div>
-        <div><?= str_replace('_', ' ', $task['status']) ?></div>
-        <div></div>
+        <div id="statusCell"><?= str_replace('_', ' ', $task['status']) ?></div>
+        <div id="actionCell">
+            <?php if ($task['status'] === 'available'): ?>
+                <button id="takeBtn" data-id="<?= $task['id'] ?>">Take</button>
+            <?php endif; ?>
+        </div>
     </div>
 </div>
 <footer>


### PR DESCRIPTION
## Summary
- Add authorization controls and bank display to individual task view
- Allow taking a task and show its current status or countdown
- Introduce dedicated JS to manage auth, claiming and timers on task page

## Testing
- `node --check assets/task.js`
- `php -l task.php`


------
https://chatgpt.com/codex/tasks/task_e_688feb4b5a9c83329da2fea3a209bf8b