### PR TITLE
Add task archiving with admin controls

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -321,6 +321,11 @@ function formatDuration($minutes) {
       </div>
       <div>
         <button type="submit">Save</button>
+        <?php if ($task['status'] === 'archived'): ?>
+          <button type="submit" formaction="/api/admin_tasks.php" formmethod="POST" name="action" value="unarchive">Unarchive</button>
+        <?php else: ?>
+          <button type="submit" formaction="/api/admin_tasks.php" formmethod="POST" name="action" value="archive">Archive</button>
+        <?php endif; ?>
         <button type="submit" formaction="/api/admin_tasks.php" formmethod="POST" name="action" value="delete" onclick="return confirm('Delete this task?')">Delete</button>
       </div>
     </form>

--- a/api/admin_tasks.php
+++ b/api/admin_tasks.php
@@ -72,6 +72,16 @@ switch ($action) {
     $stmt = $pdo->prepare("DELETE FROM tasks WHERE id = ?");
     $stmt->execute([$taskId]);
     break;
+
+  case 'archive':
+    $stmt = $pdo->prepare("UPDATE tasks SET status = 'archived', assigned_to = NULL, start_time = NULL WHERE id = ?");
+    $stmt->execute([$taskId]);
+    break;
+
+  case 'unarchive':
+    $stmt = $pdo->prepare("UPDATE tasks SET status = 'available' WHERE id = ?");
+    $stmt->execute([$taskId]);
+    break;
 }
 
 header("Location: /admin.php");

--- a/assets/script.js
+++ b/assets/script.js
@@ -408,7 +408,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
                     }
 
-                    if (div.classList.contains('completed')) {
+                    if (div.classList.contains('completed') || div.classList.contains('archived')) {
                         taskListCompleted.appendChild(div);
                         taskListCompleted.style.display = "block";
                     } else {

--- a/assets/style.css
+++ b/assets/style.css
@@ -128,6 +128,10 @@ span > strong:hover {
 .task.completed {
     background-color: palegreen;
 }
+.task.archived {
+    background-color: #d3d3d3;
+    color: #555;
+}
 .pending_review > div {
     opacity: 1;
 }

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE tasks (
   reward DECIMAL(10,2),
   estimated_minutes INT,
   date_posted DATETIME DEFAULT CURRENT_TIMESTAMP,
-  status ENUM('available', 'in_progress', 'pending_review', 'completed') DEFAULT 'available',
+  status ENUM('available', 'in_progress', 'pending_review', 'completed', 'archived') DEFAULT 'available',
   assigned_to VARCHAR(255),
   start_time DATETIME,
   submission_time DATETIME,


### PR DESCRIPTION
## Summary
- add archived status in schema and backend
- allow admins to archive/unarchive tasks
- show archived tasks in Completed list with gray styling

## Testing
- `php -l admin.php`
- `php -l api/admin_tasks.php`

------
https://chatgpt.com/codex/tasks/task_e_68a68cfcc91483329612bef581d3668d