### PR TITLE
Add task pinning for admin

### DIFF
--- a/api/admin_tasks.php
+++ b/api/admin_tasks.php
@@ -82,6 +82,16 @@ switch ($action) {
     $stmt = $pdo->prepare("UPDATE tasks SET status = 'available' WHERE id = ?");
     $stmt->execute([$taskId]);
     break;
+
+  case 'pin':
+    $stmt = $pdo->prepare("UPDATE tasks SET pinned = 1 WHERE id = ?");
+    $stmt->execute([$taskId]);
+    break;
+
+  case 'unpin':
+    $stmt = $pdo->prepare("UPDATE tasks SET pinned = 0 WHERE id = ?");
+    $stmt->execute([$taskId]);
+    break;
 }
 
 header("Location: /admin.php");

--- a/api/tasks.php
+++ b/api/tasks.php
@@ -15,13 +15,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $taskId   = intval($_GET['id'] ?? 0);
 
     if ($taskId) {
-        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks WHERE id = ?");
+        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category, pinned FROM tasks WHERE id = ?");
         $stmt->execute([$taskId]);
     } elseif ($passcode) {
-        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks WHERE last_rejected IS NULL OR last_rejected != ? ORDER BY date_posted DESC");
+        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category, pinned FROM tasks WHERE last_rejected IS NULL OR last_rejected != ? ORDER BY pinned DESC, date_posted DESC");
         $stmt->execute([$passcode]);
     } else {
-        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category FROM tasks ORDER BY date_posted DESC");
+        $stmt = $pdo->prepare("SELECT id, title, description, links, attachments, reward, estimated_minutes, date_posted, status, assigned_to, start_time, submission_time, category, pinned FROM tasks ORDER BY pinned DESC, date_posted DESC");
         $stmt->execute();
     }
     $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);

--- a/assets/script.js
+++ b/assets/script.js
@@ -259,7 +259,7 @@ document.addEventListener("DOMContentLoaded", () => {
                     div.innerHTML = `
 
           <div>
-            <div><strong><a href="task.php?id=${task.id}">[${task.id}] ${task.title}</a></strong></div>
+            <div><strong>${task.pinned ? '<span class="pinned-icon" title="Pinned">📌</span>' : ''}<a href="task.php?id=${task.id}">[${task.id}] ${task.title}</a></strong></div>
             <div class="task-meta">Posted on ${new Date(task.date_posted).toLocaleString()}</div>
             ${catSpans}
           </div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -112,6 +112,9 @@ span > strong:hover {
 .task > div:last-child {
     line-height: 2;
 }
+.pinned-icon {
+    margin-right: 4px;
+}
 .task.pending_review > div:last-child {
     line-height: normal;
     font-size: 11px;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -14,6 +14,7 @@ CREATE TABLE tasks (
   links TEXT,
   category VARCHAR(255),
   attachments TEXT,
+  pinned TINYINT(1) DEFAULT 0,
   reward DECIMAL(10,2),
   estimated_minutes INT,
   date_posted DATETIME DEFAULT CURRENT_TIMESTAMP,

--- a/task.php
+++ b/task.php
@@ -7,7 +7,7 @@ if (!$id) {
     exit;
 }
 
-$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, assigned_to, category, start_time FROM tasks WHERE id = ?");
+$stmt = $pdo->prepare("SELECT id, title, description, reward, estimated_minutes, date_posted, status, assigned_to, category, start_time, pinned FROM tasks WHERE id = ?");
 $stmt->execute([$id]);
 $task = $stmt->fetch(PDO::FETCH_ASSOC);
 if (!$task) {
@@ -62,7 +62,7 @@ if (is_dir($dir)) {
     </div>
     <div id="taskRow" class="task <?= htmlspecialchars($task['status']) ?>" data-id="<?= $task['id'] ?>" data-owner="<?= htmlspecialchars($task['assigned_to'] ?? '') ?>" data-status="<?= htmlspecialchars($task['status']) ?>" data-start="<?= htmlspecialchars($task['start_time'] ? gmdate('c', strtotime($task['start_time'])) : '') ?>" data-estimated-ms="<?= $task['estimated_minutes'] * 60000 ?>">
         <div>
-            <div><strong>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
+            <div><strong><?= $task['pinned'] ? '📌 ' : '' ?>[<?= $task['id'] ?>] <?= htmlspecialchars($task['title']) ?></strong></div>
             <div class="task-meta">Posted on <?= $task['date_posted'] ?></div>
             <span class="task-category"><?= htmlspecialchars($task['category'] ?? '') ?></span>
         </div>


### PR DESCRIPTION
## Summary
- Allow admins to mark tasks as pinned or unpinned from the admin panel
- Show pinned tasks first on task listings with a pushpin icon
- Include `pinned` column in schema and API responses

## Testing
- `php -l admin.php`
- `php -l api/admin_tasks.php`
- `php -l api/tasks.php`
- `php -l task.php`
- `node --check assets/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a727ca80cc8332acd1055bf59b0885