### PR TITLE
Fix pinned icon display for tasks

### DIFF
--- a/api/tasks.php
+++ b/api/tasks.php
@@ -27,6 +27,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $tasks = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     foreach ($tasks as &$task) {
+        $task['pinned'] = (int)$task['pinned'];
         $dir = __DIR__ . '/../uploads/' . $task['id'] . '/in';
         $attachments = [];
         if (is_dir($dir)) {


### PR DESCRIPTION
## Summary
- Ensure tasks API outputs numeric `pinned` flag so front-end only shows pins for pinned tasks

## Testing
- `php -l api/tasks.php`


------
https://chatgpt.com/codex/tasks/task_e_68a73181fe2883328b9a9288f6c199dd