### PR TITLE
Add worker email notifications with SMTP config

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'smtp_host' => 'smtp.example.com',
+    'smtp_username' => 'user@example.com',
+    'smtp_password' => 'password',
+    'smtp_from' => 'no-reply@example.com'
+];

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -4,6 +4,7 @@ USE task_tracker;
 CREATE TABLE users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   passcode VARCHAR(255) UNIQUE NOT NULL,
+  email VARCHAR(255),
   note TEXT
 );
 


### PR DESCRIPTION
## Summary
- allow storing worker email addresses in the users table
- send approval/rejection emails to workers with payout details
- centralize SMTP configuration in new `config.php`

## Testing
- `php -l api/approve.php api/reject.php config.php`


------
https://chatgpt.com/codex/tasks/task_e_68a7ac08b4a883329fd0d2c15342b767